### PR TITLE
트레이너 소개 페이지 기능구현

### DIFF
--- a/app/introduceTrainer/components/IntroTrainerForm.tsx
+++ b/app/introduceTrainer/components/IntroTrainerForm.tsx
@@ -10,22 +10,30 @@ import { PicturesElement } from "@/components/PicturesElement";
 import { Picture } from "@/components/PicturesElement";
 import { useSetInfoTrainer } from "../api/useSetInfoTrainer";
 import { useQueryClient } from "@tanstack/react-query";
+import PictureExist from "./PictureExist";
 interface TrainerInfo {
   simpleInfo: string;
   content: string;
   gymName: string;
 }
-interface getTrainerIntro {
+export interface ImgType {
+  imgName: string;
+  imgUrl: string;
+}
+
+export interface getTrainerIntro {
   gymName: string;
   simpleIntro: string;
   introContent: string;
+  careerImgList: Array<ImgType>;
 }
 export default function IntroTrainerForm() {
-  const [pictureArr, setPictureArr] = useState<Array<Picture>>([]);
   const queryClient = useQueryClient();
   const data: getTrainerIntro | undefined = queryClient.getQueryData([
     "trainerIntro",
   ]);
+  const [pictureArr, setPictureArr] = useState<Array<Picture>>([]);
+  const [deleteImg, setDeleteImg] = useState<Array<string>>([]);
   console.log("data다아앙", data);
   const mutation = useSetInfoTrainer();
   const {
@@ -35,9 +43,9 @@ export default function IntroTrainerForm() {
   } = useForm<TrainerInfo>({
     resolver: zodResolver(zodTrainerSchema),
     defaultValues: {
-      gymName: `${data?.gymName}`,
-      simpleInfo: `${data?.simpleIntro}`,
-      content: `${data?.introContent}`,
+      gymName: data?.gymName ?? undefined,
+      simpleInfo: data?.simpleIntro ?? undefined,
+      content: data?.introContent ?? undefined,
     },
   });
   const onSubmit = (data: TrainerInfo) => {
@@ -45,9 +53,16 @@ export default function IntroTrainerForm() {
     formdata.append("gymName", data.gymName);
     formdata.append("simpleIntro", data.simpleInfo);
     formdata.append("introContent", data.content);
+
     pictureArr.forEach((picture) => {
       formdata.append("careerImgList", picture.file);
     });
+    if (deleteImg.length > 0) {
+      deleteImg.forEach((img) => {
+        formdata.append("deletedImgList", img);
+      });
+    }
+
     mutation.mutate(formdata);
   };
 
@@ -83,9 +98,15 @@ export default function IntroTrainerForm() {
       )}
 
       <span className="my-3 text-sm font-semibold">자격 증명</span>
-
+      {data?.careerImgList ? (
+        <PictureExist
+          fetchImg={data.careerImgList}
+          setDeleteImg={setDeleteImg}
+        />
+      ) : (
+        <></>
+      )}
       <PicturesElement pictureArr={pictureArr} setPictureArr={setPictureArr} />
-
       <LightButton type="submit">트레이너 소개 등록</LightButton>
     </form>
   );

--- a/app/introduceTrainer/components/IntroTrainerForm.tsx
+++ b/app/introduceTrainer/components/IntroTrainerForm.tsx
@@ -34,7 +34,7 @@ export default function IntroTrainerForm() {
   ]);
   const [pictureArr, setPictureArr] = useState<Array<Picture>>([]);
   const [deleteImg, setDeleteImg] = useState<Array<string>>([]);
-  console.log("data다아앙", data);
+
   const mutation = useSetInfoTrainer();
   const {
     register,

--- a/app/introduceTrainer/components/PictureExist.tsx
+++ b/app/introduceTrainer/components/PictureExist.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { ImgType } from "./IntroTrainerForm";
+import Image from "next/image";
+import close from "@/public/join/close.png";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRef, Dispatch, SetStateAction } from "react";
+import { getTrainerIntro } from "./IntroTrainerForm";
+interface ImgProps {
+  fetchImg: Array<ImgType>;
+  setDeleteImg: Dispatch<SetStateAction<Array<string>>>;
+}
+
+export default function PictureExist({ fetchImg, setDeleteImg }: ImgProps) {
+  const queryClient = useQueryClient();
+  const data: getTrainerIntro | undefined = queryClient.getQueryData([
+    "trainerIntro",
+  ]);
+
+  const onRemoveImage = (index: number) => () => {
+    const updatedImages = fetchImg.filter((_, idx) => idx !== index);
+    queryClient.setQueryData(
+      ["trainerIntro"],
+      (prev: { careerImgList: ImgType[] }) => {
+        const copy = {
+          ...prev,
+          careerImgList: updatedImages,
+        };
+        return copy;
+      },
+    );
+    setDeleteImg((prev) => [...prev, fetchImg[index].imgName]);
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap">
+        {fetchImg?.map(
+          (v, index) =>
+            v && (
+              <div key={index} className=" w-[30%] p-1  relative">
+                <button
+                  className="absolute top-1 left-1"
+                  onClick={onRemoveImage(index)}
+                  type="button"
+                >
+                  <Image src={close} alt="close" />
+                </button>
+                <img src={v.imgUrl} alt="미리보기" className="w-full h-full" />
+              </div>
+            ),
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/introduceTrainer/zodTrainerSchema.ts
+++ b/app/introduceTrainer/zodTrainerSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const zodTrainerSchema = z.object({
-  simpleInfo: z.string().min(10, { message: "소개는 5글자이상 해주세요" }),
-  content: z.string().min(5, { message: "내용을 5글자이상 입력하세요" }),
-  gymName: z.string().min(5, { message: "소개는 5글자이상 해주세요" }),
+  simpleInfo: z.string().min(3, { message: "소개를 더 해주세요" }),
+  content: z.string().min(3, { message: "내용을 더 입력하세요" }),
+  gymName: z.string().min(3, { message: "소개는 더 해주세요" }),
 });

--- a/app/login/api/useLogin.ts
+++ b/app/login/api/useLogin.ts
@@ -13,10 +13,8 @@ export const useLogin = () => {
       return response;
     },
     onSuccess(response: { token: string }) {
-      console.log("토큰을 찾아보자", response.token);
       setCookie("token", response.token);
       router.replace("/");
-      console.log("로그인 됐다앙~", response);
       setTimeout(() => {
         alert("로그인이 완료되었습니다.");
       }, 1000);

--- a/app/login/components/LoginComponent.tsx
+++ b/app/login/components/LoginComponent.tsx
@@ -1,6 +1,6 @@
 import SocialLoginButtons from "./SocialLoginButtons";
 import LoginForm from "./LoginForm";
-
+import Link from "next/link";
 export default function LoginComponent() {
   return (
     <div className="flex flex-col h-screen bg-white mx-auto">
@@ -9,7 +9,7 @@ export default function LoginComponent() {
       </h1>
       <LoginForm />
       <div className="flex flex-1 text-[24px] text-[#175601] items-center justify-center border-y-slate-200 border-2">
-        <div>회원가입</div>
+        <Link href="/join">회원가입</Link>
       </div>
       <SocialLoginButtons />
     </div>

--- a/app/programManage/components/ProgramManageComponent.tsx
+++ b/app/programManage/components/ProgramManageComponent.tsx
@@ -15,17 +15,15 @@ export const ProgramManageComponent = () => {
 
   return (
     <div className=" px-3  bg-white">
-      <div className="flex flex-col items-center">
-        <div className="bg-slate-500 h-[90px] w-[90px] rounded-full mb-2" />
-        <div className="text-black text-xl">안녕하세요 트레이너님!</div>
+      <div className=" flex justify-center mx-2">
+        <LightButton className="text-base " height="h-[40px]" onClick={addForm}>
+          +프로그램 추가하기
+        </LightButton>
       </div>
-      <LightButton className="text-base" height="h-[40px]" onClick={addForm}>
-        +프로그램 추가하기
-      </LightButton>
-      {programForms.map((component) => component)}
 
+      {programForms.map((component) => component)}
       <div className=" flex justify-center sticky bottom-2 right-3 left-3 ">
-        <button className=" h-[48px] bg-[#1C743C] rounded-[6px] w-full sticky">
+        <button className="m-2 h-[48px] bg-[#1C743C] rounded-[6px] w-full sticky text-white">
           저장하기
         </button>
       </div>

--- a/app/programManage/components/TrainerProfile.tsx
+++ b/app/programManage/components/TrainerProfile.tsx
@@ -1,0 +1,29 @@
+"use client";
+import Image from "next/image";
+import userThumb from "@/public/trainerMyPageIcons/userThumb.png";
+import { useQueryClient } from "@tanstack/react-query";
+import { UserDataType } from "@/app/trainerMyPage/components/MyInfoChunk";
+export default function TrainerProfile() {
+  const queryClient = useQueryClient();
+
+  const data: UserDataType | undefined = queryClient.getQueryData(["userData"]);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="flex relative w-[80px] rounded-[100%] overflow-hidden mr-2 h-[80px]">
+        {data?.data.profileImagePath ? (
+          <Image
+            src={data.data.profileImagePath}
+            alt="profileImage"
+            layout="fill"
+            objectFit="contain"
+          ></Image>
+        ) : (
+          <Image src={userThumb} alt="userThumb"></Image>
+        )}
+      </div>
+
+      <div className="text-black text-xl">안녕하세요 트레이너님!</div>
+    </div>
+  );
+}

--- a/app/programManage/page.tsx
+++ b/app/programManage/page.tsx
@@ -1,8 +1,10 @@
 import { ProgramManageComponent } from "./components/ProgramManageComponent";
 import React from "react";
+import TrainerProfile from "./components/TrainerProfile";
 export default function ProgramManagementPage() {
   return (
     <div className="  bg-white flex flex-col">
+      <TrainerProfile />
       <ProgramManageComponent />
     </div>
   );

--- a/app/trainerMyPage/components/MyInfoChunk.tsx
+++ b/app/trainerMyPage/components/MyInfoChunk.tsx
@@ -3,10 +3,10 @@ import Image from "next/image";
 import userThumb from "@/public/trainerMyPageIcons/userThumb.png";
 import logout from "@/public/trainerMyPageIcons/logoutButton.png";
 import infoEditButton from "@/public/trainerMyPageIcons/infoEditButton.png";
-import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
-interface UserDataType {
+export interface UserDataType {
   data: {
     name: string;
     address: string;
@@ -24,16 +24,14 @@ export default function MyInfoChunk() {
   };
   return (
     <div className=" flex">
-      <div className="flex relative w-[100px] rounded-[100%] overflow-hidden">
+      <div className="flex relative w-[100px] rounded-[100%] overflow-hidden mr-2">
         {data?.data.profileImagePath ? (
-          <div className=" ">
-            <Image
-              src={data.data.profileImagePath}
-              alt="profileImage"
-              layout="fill"
-              objectFit="cover"
-            ></Image>
-          </div>
+          <Image
+            src={data.data.profileImagePath}
+            alt="profileImage"
+            layout="fill"
+            objectFit="contain"
+          ></Image>
         ) : (
           <Image src={userThumb} alt="userThumb"></Image>
         )}

--- a/components/PicturesElement.tsx
+++ b/components/PicturesElement.tsx
@@ -2,7 +2,7 @@
 import Image from "next/image";
 import { Dispatch, SetStateAction, ChangeEventHandler, useRef } from "react";
 import { BGWhiteButton } from "./BGWhiteButton";
-import close from "../public/join/close.png";
+import close from "@/public/join/close.png";
 export interface Picture {
   dataUrl: string;
   file: File;
@@ -32,6 +32,7 @@ export const PicturesElement = ({
           (resolve, reject) => {
             const reader = new FileReader();
             reader.onloadend = () => {
+              console.log("file이야우아", file);
               resolve({
                 dataUrl: reader.result as string,
                 file,

--- a/components/formElement/TextArea.tsx
+++ b/components/formElement/TextArea.tsx
@@ -14,7 +14,7 @@ export default function TextArea({
       <span className="text-sm font-semibold text-black">{title}</span>
       <textarea
         placeholder={placeholder}
-        className=" text-[#697077] w-full h-[100px]  border border-[#d9d9d9] rounded-[12px]  focus:outline-none focus:ring-0 focus:border-[#22C55E] hover:border-[#22C55E] transition-colors duration-500"
+        className=" text-[#697077] pl-2 w-full h-[100px]  border border-[#d9d9d9] rounded-[12px]  focus:outline-none focus:ring-0 focus:border-[#22C55E] hover:border-[#22C55E] transition-colors duration-500"
         {...register}
       ></textarea>
     </label>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ["teutoo-test-bucket.s3.ap-northeast-2.amazonaws.com"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "teutoo-test-bucket.s3.ap-northeast-2.amazonaws.com",
+        port: "",
+        pathname: "/**",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
1. 기존에 작성한 트레이너 소개 페이지 존재 X => 아무것도 입력되지않은 소개페이지로 이동
2.  기존에 작성한 트레이너 소개 페이지 존재 O => 관련 데이터가 defalutValues로 입력된 상태로 이동
3. 트레이너 소개 페이지에서 자격 이미지 관련
3-1) 이미 서버에 입력된 이미지를 X클릭 => react-query 캐시에서 해당 이미지만 삭제, 서버통신을 위한 deleteImg 배열에 추가후 추후에 전송
3-2) 서버에 입력되지 않은 이미지를 X클릭 => 브라우저 useState에서 해당 이미지만 삭제 